### PR TITLE
Update to build and pass tests under JDK 8 through 11 on Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,169 @@
+#### joe made this: http://goel.io/joe
+
+#### java ####
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+
+#### maven ####
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+
+# Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
+!/.mvn/wrapper/maven-wrapper.jar
+
+
+#### jetbrains ####
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+cmake-build-release/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+
+#### emacs ####
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+
+#### macos ####
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
   </state>
 </component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Maven default annotation processors profile" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <module name="mrt-core" />
+        <module name="mrt-jena" />
+        <module name="mrt-json" />
+      </profile>
+    </annotationProcessing>
+  </component>
+</project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/core" charset="UTF-8" />
+    <file url="PROJECT" charset="UTF-8" />
+  </component>
+</project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,10 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="ConstantConditions" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="false" />
+      <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="false" />
+    </inspection_tool>
     <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
       <option name="processCode" value="true" />
       <option name="processLiterals" value="true" />

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,11 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
+      <option name="processCode" value="true" />
+      <option name="processLiterals" value="true" />
+      <option name="processComments" value="true" />
+    </inspection_tool>
+    <inspection_tool class="TestFailedLine" enabled="false" level="WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EmacsSettings">
+    <option name="emacsPath" value="/usr/bin/emacs" />
+  </component>
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="11" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: java
+
+jdk:
+    - openjdk11
+    - openjdk10
+    - openjdk9
+    - openjdk8
+    

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -131,7 +131,12 @@
             <!--version>0.7.2-SNAPSHOT</version-->
             <version>0.7.1-rc3</version>
         </dependency>
-  
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+
 
 <!-- upgrade tika handling >> -->
         <dependency>

--- a/core/src/main/java/org/cdlib/mrt/core/DateState.java
+++ b/core/src/main/java/org/cdlib/mrt/core/DateState.java
@@ -54,11 +54,11 @@ public class DateState
 
     /**
      * Constructor
-     * @param seconds base second count
+     * @param milliseconds base millisecond count
      */
-    public DateState(long seconds)
+    public DateState(long milliseconds)
     {
-        setDate(new Date(seconds));
+        setDate(new Date(milliseconds));
     }
 
     /**
@@ -127,8 +127,8 @@ public class DateState
     }
 
     /**
-     * Return second format of this Date
-     * @return second count for this Date
+     * Return milliseconds since January 1, 1970, 00:00:00 GMT for this date
+     * @return millisecond count for this Date, or 0 if the wrapped date is null
      */
     public long getTimeLong()
     {

--- a/core/src/main/java/org/cdlib/mrt/core/DateState.java
+++ b/core/src/main/java/org/cdlib/mrt/core/DateState.java
@@ -30,6 +30,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
 package org.cdlib.mrt.core;
 
 import java.io.Serializable;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import org.cdlib.mrt.utility.DateUtil;
 import org.cdlib.mrt.utility.StateStringInf;
@@ -41,7 +42,8 @@ public class DateState
         implements StateStringInf, Serializable
 {
     public static final String DBDATEPATTERN = "yyyy-MM-dd HH:mm:ss";
-    protected Date date = null;
+
+    private ZonedDateTime date;
 
     /**
      * Constructor
@@ -49,7 +51,7 @@ public class DateState
      */
     public DateState(Date date)
     {
-        setDate(date);
+        this(date == null ? null : DateUtil.getZonedDateTimeFromDate(date));
     }
 
     /**
@@ -58,7 +60,7 @@ public class DateState
      */
     public DateState(long milliseconds)
     {
-        setDate(new Date(milliseconds));
+        this(DateUtil.getZonedDateTimeFromEpochMilli(milliseconds));
     }
 
     /**
@@ -67,16 +69,19 @@ public class DateState
      */
     public DateState(String dateTime)
     {
-            date = DateUtil.getIsoDateFromString(dateTime);
+        this(DateUtil.getZonedDateTimeFromString(dateTime));
     }
 
     /**
      * Contructor
-     * @param dateTime Iso format for date
      */
     public DateState()
     {
-        date = DateUtil.getCurrentDate();
+        this(DateUtil.getCurrentZonedDateTime());
+    }
+
+    public DateState(ZonedDateTime date) {
+        this.date = date;
     }
 
     /**
@@ -84,7 +89,7 @@ public class DateState
      * @return standard date
      */
     public Date getDate() {
-        return date;
+        return this.date == null ? null : DateUtil.getDateFromZonedDateTime(date);
     }
 
     /**
@@ -92,7 +97,7 @@ public class DateState
      * @param date Date value used for State
      */
     public void setDate(Date date) {
-        this.date = date;
+        this.date = date == null ? null : DateUtil.getZonedDateTimeFromEpochMilli(date.getTime());
     }
     
     /**
@@ -102,7 +107,7 @@ public class DateState
     public String getIsoDate()
     {
         if (date == null) return null;
-        return DateUtil.getIsoDate(date);
+        return DateUtil.getIsoDate(date, true);
     }
     
     /**
@@ -112,7 +117,7 @@ public class DateState
     public String getIsoZDate()
     {
         if (date == null) return null;
-        return DateUtil.getIsoZDate(date);
+        return DateUtil.getIsoZDate(date, true);
     }
 
     /**
@@ -123,7 +128,7 @@ public class DateState
     public String toString()
     {
         if (date == null) return "empty";
-        return DateUtil.getIsoDate(date);
+        return getIsoDate();
     }
 
     /**
@@ -133,7 +138,7 @@ public class DateState
     public long getTimeLong()
     {
         if (date == null) return 0;
-        return date.getTime();
+        return date.toInstant().toEpochMilli();
     }
 
     /**

--- a/core/src/test/java/org/cdlib/mrt/core/CheckmTest.java
+++ b/core/src/test/java/org/cdlib/mrt/core/CheckmTest.java
@@ -1,0 +1,114 @@
+package org.cdlib.mrt.core;
+
+import org.cdlib.mrt.utility.TException;
+import org.cdlib.mrt.utility.TFileLogger;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.cdlib.mrt.core.ManifestRowBatch.cols;
+import static org.cdlib.mrt.core.ManifestRowBatch.profiles;
+import static org.cdlib.mrt.core.ManifestRowCheckmAbs.getHeaders;
+import static org.cdlib.mrt.utility.LoggerInf.LogLevel.DEBUG_LOW;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CheckmTest {
+
+    // ------------------------------------------------------------
+    // Fixture
+
+    private static final ZoneId SYSTEM_ZONE_ID = ZoneId.systemDefault();
+    private static final ZoneOffset SYSTEM_ZONE_OFFSET = SYSTEM_ZONE_ID.getRules().getOffset(Instant.now());
+
+    private static final ZoneOffset OTHER_ZONE_OFFSET;
+
+    static {
+        int systemOffsetSeconds = SYSTEM_ZONE_OFFSET.getTotalSeconds();
+        int otherOffsetSeconds = systemOffsetSeconds + 3600;
+        if (otherOffsetSeconds < ZoneOffset.MAX.getTotalSeconds()) {
+            OTHER_ZONE_OFFSET = ZoneOffset.ofTotalSeconds(otherOffsetSeconds);
+        } else {
+            OTHER_ZONE_OFFSET = ZoneOffset.ofTotalSeconds(systemOffsetSeconds - 3600);
+        }
+    }
+
+    private Checkm checkm;
+
+    @Before
+    public void setUp() throws TException {
+        TFileLogger logger = new TFileLogger(getClass().getSimpleName(), DEBUG_LOW, DEBUG_LOW);
+        checkm = new Checkm(logger, getHeaders(profiles, cols));
+    }
+
+    // ------------------------------------------------------------
+    // Helper methods
+
+    private ZonedDateTime nowZdt(ZoneOffset offset) {
+        // .withNano(0) is a hack to get DateTimeFormatter not to output fractional seconds
+        return ZonedDateTime.now(offset).withNano(0);
+    }
+
+    private ZonedDateTime nowSystemZdt() {
+        return nowZdt(SYSTEM_ZONE_OFFSET);
+    }
+
+    private ZonedDateTime nowUtcZdt() {
+        return nowZdt(ZoneOffset.UTC);
+    }
+
+    private ZonedDateTime nowOtherZdt() {
+        return nowZdt(OTHER_ZONE_OFFSET);
+    }
+
+    private String toIso8601(ZonedDateTime zdt) {
+        return zdt.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    }
+
+    // ------------------------------------------------------------
+    // Tests
+
+    @Test
+    public void getLinePreservesSystemTime() throws TException {
+        String expected = toIso8601(nowSystemZdt());
+        FileComponent fc = new FileComponent();
+        fc.setCreated(new DateState(expected));
+
+        String line = checkm.getLine(fc);
+        assertTrue(
+                String.format("Expected timestamp '%s' not found in line '%s'", expected, line),
+                line.contains(expected)
+        );
+    }
+
+    @Test
+    public void getLinePreservesUtcTime() throws TException {
+        String expected = toIso8601(nowUtcZdt());
+        FileComponent fc = new FileComponent();
+        fc.setCreated(new DateState(expected));
+
+        String line = checkm.getLine(fc);
+        assertTrue(
+                String.format("Expected timestamp '%s' not found in line '%s'", expected, line),
+                line.contains(expected)
+        );
+    }
+
+    @Test
+    public void getLinePreservesOtherTime() throws TException {
+        String expected = toIso8601(nowOtherZdt());
+        FileComponent fc = new FileComponent();
+        fc.setCreated(new DateState(expected));
+
+        String line = checkm.getLine(fc);
+        assertTrue(
+                String.format("Expected timestamp '%s' not found in line '%s'", expected, line),
+                line.contains(expected)
+        );
+    }
+}

--- a/core/src/test/java/org/cdlib/mrt/core/CheckmTest.java
+++ b/core/src/test/java/org/cdlib/mrt/core/CheckmTest.java
@@ -15,7 +15,6 @@ import static org.cdlib.mrt.core.ManifestRowBatch.cols;
 import static org.cdlib.mrt.core.ManifestRowBatch.profiles;
 import static org.cdlib.mrt.core.ManifestRowCheckmAbs.getHeaders;
 import static org.cdlib.mrt.utility.LoggerInf.LogLevel.DEBUG_LOW;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class CheckmTest {

--- a/core/src/test/java/org/cdlib/mrt/core/DateStateTest.java
+++ b/core/src/test/java/org/cdlib/mrt/core/DateStateTest.java
@@ -1,0 +1,169 @@
+package org.cdlib.mrt.core;
+
+import org.junit.Test;
+
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+public class DateStateTest {
+
+    // ------------------------------------------------------------
+    // Fixture
+
+    private static final ZoneId SYSTEM_ZONE_ID = ZoneId.systemDefault();
+
+    // ------------------------------------------------------------
+    // Helper methods
+
+    private static long nowMillis() {
+        long nowSeconds = Instant.now().atZone(SYSTEM_ZONE_ID).toEpochSecond();
+        return TimeUnit.SECONDS.toMillis(nowSeconds);
+    }
+
+    private Date nowDate() {
+        long nowMillis = nowMillis();
+        return new Date(nowMillis);
+    }
+
+    private String formatIso8601(Date date) {
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+        format.setTimeZone(TimeZone.getTimeZone(SYSTEM_ZONE_ID));
+        return format.format(date);
+    }
+
+    private String formatIso8601Zulu(Date date) {
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+        format.setTimeZone(TimeZone.getTimeZone(ZoneOffset.UTC.getId()));
+        return format.format(date);
+    }
+
+    // ------------------------------------------------------------
+    // Tests
+
+    // ------------------------------
+    // Constructors
+
+    @Test
+    public void constructNoArgs() {
+        DateState state = new DateState();
+        Date stateDate = state.getDate();
+        long nowMillis = nowMillis();
+        long diff = Math.abs(nowMillis - stateDate.getTime());
+        assertTrue(diff < 1000L);
+    }
+
+    @Test
+    public void constructWithDate() {
+        Date nowDate = nowDate();
+        DateState state = new DateState(nowDate);
+        assertEquals(nowDate, state.getDate());
+    }
+
+    @Test
+    public void constructWithDateAcceptsNull() {
+        DateState state = new DateState((Date) null);
+        assertNull(state.getDate());
+    }
+
+    @Test
+    public void constructWithMillis() {
+        long nowMillis = nowMillis();
+        Date nowDate = new Date(nowMillis);
+        DateState state = new DateState(nowMillis);
+        assertEquals(nowDate, state.getDate());
+    }
+
+    @Test
+    public void constructWithString() {
+        Date nowDate = nowDate();
+        String nowIso8601 = formatIso8601(nowDate);
+        DateState state = new DateState(nowIso8601);
+        assertEquals(nowDate, state.getDate());
+    }
+
+    // ------------------------------
+    // Accessors
+
+    @Test
+    public void setDate() {
+        DateState state = new DateState((Date) null);
+        Date nowDate = nowDate();
+        state.setDate(nowDate);
+        assertEquals(nowDate, state.getDate());
+    }
+
+    @Test
+    public void getIsoDate() {
+        long nowMillis = nowMillis();
+        Date nowDate = new Date(nowMillis);
+        DateState state = new DateState(nowMillis);
+        String expected = formatIso8601(nowDate);
+        assertEquals(expected, state.getIsoDate());
+    }
+
+    @Test
+    public void getIsoDateReturnsNullForNull() {
+        DateState state = new DateState((Date) null);
+        assertNull(state.getIsoDate());
+    }
+
+    @Test
+    public void getIsoZDate() {
+        long nowMillis = nowMillis();
+        Date nowDate = new Date(nowMillis);
+        DateState state = new DateState(nowMillis);
+        String expected = formatIso8601Zulu(nowDate);
+        assertEquals(expected, state.getIsoZDate());
+    }
+
+    @Test
+    public void getIsoZDateReturnsNullForNull() {
+        DateState state = new DateState((Date) null);
+        assertNull(state.getIsoZDate());
+    }
+
+    @Test
+    public void toStringReturnsIsoDate() {
+        long nowMillis = nowMillis();
+        Date nowDate = new Date(nowMillis);
+        DateState state = new DateState(nowMillis);
+        String expected = formatIso8601(nowDate);
+        assertEquals(expected, state.toString());
+    }
+
+    @Test
+    public void toStringReturnsEmptyForNull() {
+        DateState state = new DateState((Date) null);
+        assertEquals("empty", state.toString());
+    }
+
+    @Test
+    public void getTimeLong() {
+        long nowMillis = nowMillis();
+        Date nowDate = new Date(nowMillis);
+        DateState state = new DateState(nowDate);
+        assertEquals(nowMillis, state.getTimeLong());
+    }
+
+    @Test
+    public void getTimeLongReturnsZeroForNUll() {
+        DateState state = new DateState((Date) null);
+        assertEquals(0L, state.getTimeLong());
+    }
+
+    @Test
+    public void maxTime() {
+        long start = nowMillis();
+        DateState lesser = new DateState(start);
+        DateState greater = new DateState(start + 1000L);
+        assertEquals(greater, lesser.maxTime(greater));
+        assertEquals(greater, greater.maxTime(lesser));
+    }
+}

--- a/core/src/test/java/org/cdlib/mrt/core/DateStateTest.java
+++ b/core/src/test/java/org/cdlib/mrt/core/DateStateTest.java
@@ -1,6 +1,5 @@
 package org.cdlib.mrt.core;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.text.SimpleDateFormat;
@@ -45,6 +44,27 @@ public class DateStateTest {
     private Date nowDate() {
         long nowMillis = nowMillis();
         return new Date(nowMillis);
+    }
+
+    private ZonedDateTime nowZdt(ZoneOffset offset) {
+        // .withNano(0) is a hack to get DateTimeFormatter not to output fractional seconds
+        return ZonedDateTime.now(offset).withNano(0);
+    }
+
+    private ZonedDateTime nowSystemZdt() {
+        return nowZdt(SYSTEM_ZONE_OFFSET);
+    }
+
+    private ZonedDateTime nowUtcZdt() {
+        return nowZdt(ZoneOffset.UTC);
+    }
+
+    private ZonedDateTime nowOtherZdt() {
+        return nowZdt(OTHER_ZONE_OFFSET);
+    }
+
+    private String toIso8601(ZonedDateTime zdt) {
+        return zdt.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
     }
 
     private static long toMillis(ZonedDateTime zdt) {
@@ -110,9 +130,8 @@ public class DateStateTest {
 
     @Test
     public void constructWithStringSupportsUTC() {
-        // .withNano(0) is a hack to get DateTimeFormatter not to output fractional seconds
-        ZonedDateTime nowUtcZDT = ZonedDateTime.now(ZoneOffset.UTC).withNano(0);
-        String nowUtcIso8601 = nowUtcZDT.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        ZonedDateTime nowUtcZDT = nowUtcZdt();
+        String nowUtcIso8601 = toIso8601(nowUtcZDT);
         DateState state = new DateState(nowUtcIso8601);
         long expected = toMillis(nowUtcZDT);
         assertEquals(expected, state.getTimeLong());
@@ -120,9 +139,8 @@ public class DateStateTest {
 
     @Test
     public void constructWithStringSupportsOtherTimeZones() {
-        // .withNano(0) is a hack to get DateTimeFormatter not to output fractional seconds
-        ZonedDateTime nowOtherZdt = ZonedDateTime.now(OTHER_ZONE_OFFSET).withNano(0);
-        String nowOtherIso8601 = nowOtherZdt.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        ZonedDateTime nowOtherZdt = nowOtherZdt();
+        String nowOtherIso8601 = toIso8601(nowOtherZdt);
         DateState state = new DateState(nowOtherIso8601);
         long expected = toMillis(nowOtherZdt);
         assertEquals(expected, state.getTimeLong());
@@ -178,25 +196,26 @@ public class DateStateTest {
         assertEquals(expected, state.toString());
     }
 
-    @Ignore
     @Test
-    public void toStringPreservesLocalTime() {
-        // TODO: test this directly in Checkm.getLine()
-        fail("not implemented");
+    public void toStringPreservesSystemTime() {
+        String nowSystemIso8601 = toIso8601(nowSystemZdt());
+        DateState state = new DateState(nowSystemIso8601);
+        assertEquals(nowSystemIso8601, state.toString());
     }
 
-    @Ignore
     @Test
     public void toStringPreservesUTCTime() {
-        // TODO: test this directly in Checkm.getLine()
-        fail("not implemented");
+        String nowUtcIso8601 = toIso8601(nowUtcZdt());
+        DateState state = new DateState(nowUtcIso8601);
+        assertEquals(nowUtcIso8601, state.toString());
     }
 
-    @Ignore
     @Test
     public void toStringPreservesOtherTimeZone() {
         // TODO: test this directly in Checkm.getLine()
-        fail("not implemented");
+        String nowOtherIso8601 = toIso8601(nowOtherZdt());
+        DateState state = new DateState(nowOtherIso8601);
+        assertEquals(nowOtherIso8601, state.toString());
     }
 
     @Test

--- a/core/src/test/java/org/cdlib/mrt/core/DateStateTest.java
+++ b/core/src/test/java/org/cdlib/mrt/core/DateStateTest.java
@@ -23,6 +23,7 @@ public class DateStateTest {
     private static final ZoneOffset SYSTEM_ZONE_OFFSET = SYSTEM_ZONE_ID.getRules().getOffset(Instant.now());
 
     private static final ZoneOffset OTHER_ZONE_OFFSET;
+
     static {
         int systemOffsetSeconds = SYSTEM_ZONE_OFFSET.getTotalSeconds();
         int otherOffsetSeconds = systemOffsetSeconds + 3600;


### PR DESCRIPTION
1. Adds `travis.yml` file to configure Travis build.
2. Adds explicit Maven dependency on `jaxb-api` (no longer distributed with the JDK).
3. Modifies `DateState` to use [`java.time.ZonedDateTime`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/ZonedDateTime.html) internally instead of obsolete [`java.util.Date`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Date.html):
   - this allows the checkm manifest parser to preserve parsed time zone information when writing a manifest, instead of always writing timestamps in the local (system) time zone.
   - this allows `ManifestXMLTest`, `ManifestRowSemanticTest`, etc., which do round-trip comparisons, to pass even when run on a system (such as the Travis CI servers) that is not set to the `-07:00` time zone as given in the test data files.

The default Maven build (including tests) now completes successfully on OpenJDK 8, 9, 10, and 11: https://travis-ci.org/CDLUC3/mrt-core2/builds/437366023