### PR TITLE
Add explicit dependency on jaxb-api

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -131,7 +131,12 @@
             <!--version>0.7.2-SNAPSHOT</version-->
             <version>0.7.1-rc3</version>
         </dependency>
-  
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+
 
 <!-- upgrade tika handling >> -->
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -134,7 +134,7 @@
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
+            <version>2.2.12</version>
         </dependency>
 
 


### PR DESCRIPTION
Adds an explicit Maven dependency on `javax.xml.bind:jaxb-api` to deal with removal of `javax` packages from JDK 11.