### PR TITLE
explicitly include xmlbind

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -146,6 +146,14 @@
             <artifactId>jargs</artifactId>
             <version>1.0</version>
         </dependency-->
+
+        <!-- https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+
     </dependencies>
 
 </project>


### PR DESCRIPTION
Our pom files indicate builds to be 1.8 compatible. 

IF the build uses a java 11 version of javac, the `javax.xml.bind` library cannot be found.

This should resolve the issue